### PR TITLE
Change the look of table borders when printing

### DIFF
--- a/internal/table/table_test.go
+++ b/internal/table/table_test.go
@@ -8,7 +8,7 @@ import (
 func TestTable_setColumnWidth(t *testing.T) {
 	type fields struct {
 		Header      []string
-		Rows        []RowField
+		Rows        []Row
 		ColumnWidth map[string]int
 	}
 	tests := []struct {
@@ -20,7 +20,7 @@ func TestTable_setColumnWidth(t *testing.T) {
 			name: "General",
 			fields: fields{
 				Header: []string{"Name", "Age", "Active", "Mass", "Books"},
-				Rows: []RowField{
+				Rows: []Row{
 					{
 						"Name":   "John Doe",
 						"Age":    "30",
@@ -50,7 +50,7 @@ func TestTable_setColumnWidth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := &Table{
-				Header:      tt.fields.Header,
+				Headers:     tt.fields.Header,
 				Rows:        tt.fields.Rows,
 				ColumnWidth: tt.fields.ColumnWidth,
 			}

--- a/internal/user/books.go
+++ b/internal/user/books.go
@@ -42,14 +42,17 @@ func (a AvgAgePerBookSlice) SortByAge() {
 	})
 }
 
+// NewTable method satisfies the table.Printer interface.
+// It converts the slice data to strings and as a result creates a new table.Table object.
 func (a AvgAgePerBookSlice) NewTable(headers []string) (res table.Table) {
-	res.Header = headers
+	res.Headers = headers
 	for _, ele := range a {
-		field := make(table.RowField)
-		field[res.Header[0]] = Name(ele.BookTitle).String()
-		field[res.Header[1]] = Age(ele.AvgAge).String()
+		// Create a new row and fill it with values for each column.
+		row := make(table.Row)
+		row[res.Headers[0]] = Name(ele.BookTitle).String()
+		row[res.Headers[1]] = Age(ele.AvgAge).String()
 
-		res.Rows = append(res.Rows, field)
+		res.Rows = append(res.Rows, row)
 	}
 	return res
 }

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -66,17 +66,20 @@ func (b Books) String() string {
 
 type Slice []User
 
+// NewTable method satisfies the table.Printer interface.
+// It converts the slice data to strings and as a result creates a new table.Table object.
 func (users Slice) NewTable(headers []string) (res table.Table) {
-	res.Header = headers
+	res.Headers = headers
 	for _, user := range users {
-		field := make(table.RowField)
-		field[res.Header[0]] = Name(user.Name).String()
-		field[res.Header[1]] = Age(user.Age).String()
-		field[res.Header[2]] = ActiveIndex(user.ActiveIndex).String()
-		field[res.Header[3]] = Mass(user.Mass).String()
-		field[res.Header[4]] = Books(user.Books).String()
+		// Create a new row and fill it with values for each column.
+		row := make(table.Row)
+		row[res.Headers[0]] = Name(user.Name).String()
+		row[res.Headers[1]] = Age(user.Age).String()
+		row[res.Headers[2]] = ActiveIndex(user.ActiveIndex).String()
+		row[res.Headers[3]] = Mass(user.Mass).String()
+		row[res.Headers[4]] = Books(user.Books).String()
 
-		res.Rows = append(res.Rows, field)
+		res.Rows = append(res.Rows, row)
 	}
 	return res
 }

--- a/internal/user/user_test.go
+++ b/internal/user/user_test.go
@@ -138,8 +138,8 @@ func TestSlice_NewTable(t *testing.T) {
 				headers: []string{"Name", "Age", "Active", "Mass", "Books"},
 			},
 			wantRes: table.Table{
-				Header: []string{"Name", "Age", "Active", "Mass", "Books"},
-				Rows: []table.RowField{
+				Headers: []string{"Name", "Age", "Active", "Mass", "Books"},
+				Rows: []table.Row{
 					{
 						"Name":   "John Doe",
 						"Age":    "30",


### PR DESCRIPTION
- Added graphic symbols for printing table borders
- Made some renaming (variables, methods) both in the table package and in those that depend on it
- Renamed printSeparator function into printLine and made it more generic, therefore I had to change its signature
- Decomposed the setColumnWidth method
- Added a bit of comments